### PR TITLE
fix: fixed parse function return an unexpected value

### DIFF
--- a/src/helper/path.ts
+++ b/src/helper/path.ts
@@ -21,7 +21,10 @@ export function parse<T extends object, K>(obj: T, path: string, defaultVal: K):
   try {
     // eslint-disable-next-line no-new-func
     const result = new Function('obj', `return obj${path.startsWith('[') ? '' : '.'}${path};`)(obj)
-    return isEmpty(result) ? defaultVal : result
+    if (!isEmpty(result)) {
+      return result
+    }
+    return isEmpty(defaultVal) ? result : defaultVal
   } catch (error) {
     return defaultVal
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -85,6 +85,23 @@ describe('verification', function() {
       expect(reap<typeof obj, undefined>(obj, 'age')).toBeUndefined()
     })
 
+    it('with empty value', function() {
+      interface User {
+        grade: String
+      }
+      const obj: User = {
+        grade: null
+      }
+
+      expect(reap<typeof obj, undefined>(obj, 'grade')).toBeNull()
+      expect(reap<typeof obj, string>(obj, 'grade', 'A')).toBe('A')
+      expect(reap<typeof obj, undefined>(obj, 'grade', undefined)).toBeNull()
+      expect(reap<typeof obj, undefined>(obj, 'grade', null)).toBeNull()
+      expect(reap<typeof obj, number>(obj, 'grade', 0)).toBe(0)
+      expect(reap<typeof obj, boolean>(obj, 'grade', false)).toBe(false)
+      expect(reap<typeof obj, string>(obj, 'grade', '0')).toBe('0')
+    })
+
     it('just bracket notation property, string index', function() {
       const obj = {
         name: 'hello'


### PR DESCRIPTION
parse method returns an unexpected value when the property value is null.

add test code.